### PR TITLE
adding a new argument on \Backend\Shared::start for specific FastCGI Params

### DIFF
--- a/Backend/Shared.php
+++ b/Backend/Shared.php
@@ -317,7 +317,6 @@ class Shared implements \Hoa\Core\Event\Listenable {
      * @param   string  $socket             Socket URI to PHP-FPM server.
      * @param   string  $workerPath         Path to the shared worker program.
      * @param   array   $fastcgiParameters  Array of additional parameters for FastCGI.
-     * @throw  \Hoa\Worker\Backend\Exception
      * @return  bool
      */
     public static function start ( $socket, $workerPath, Array $fastcgiParameters = array() ) {

--- a/Backend/Shared.php
+++ b/Backend/Shared.php
@@ -320,25 +320,25 @@ class Shared implements \Hoa\Core\Event\Listenable {
      * @throw  \Hoa\Worker\Backend\Exception
      * @return  bool
      */
-    public static function start ( $socket, $workerPath, array $fastcgiParameters = array() ) {
+    public static function start ( $socket, $workerPath, Array $fastcgiParameters = array() ) {
 
         $server = new \Hoa\Fastcgi\Responder(
             new \Hoa\Socket\Client($socket)
         );
 
-        $headers = [
+        $headers = array(
             'GATEWAY_INTERFACE' => 'FastCGI/1.0',
             'SERVER_PROTOCOL'   => 'HTTP/1.1',
             'REQUEST_URI'       => $workerPath,
             'SCRIPT_FILENAME'   => $workerPath,
             'SCRIPT_NAME'       => DS . dirname($workerPath)
-        ];
+        );
 
-        $fastcgiParameters = array_merge([
-            'REQUEST_METHOD'    => 'GET'
-        ], $fastcgiParameters);
+        $defaultFastcgiParameters = array(
+            'REQUEST_METHOD' => 'GET'
+        );
 
-        return $server->send(array_merge($fastcgiParameters, $headers));
+        return $server->send(array_merge($defaultFastcgiParameters, $fastcgiParameters, $headers));
     }
 
     /**

--- a/Backend/Shared.php
+++ b/Backend/Shared.php
@@ -314,24 +314,31 @@ class Shared implements \Hoa\Core\Event\Listenable {
      * Start the shared worker.
      *
      * @access  public
-     * @param   string  $socket        Socket URI to PHP-FPM server.
-     * @param   string  $workerPath    Path to the shared worker program.
+     * @param   string  $socket             Socket URI to PHP-FPM server.
+     * @param   string  $workerPath         Path to the shared worker program.
+     * @param   array   $fastcgiParameters  Array of additional parameters for FastCGI.
+     * @throw  \Hoa\Worker\Backend\Exception
      * @return  bool
      */
-    public static function start ( $socket, $workerPath ) {
+    public static function start ( $socket, $workerPath, array $fastcgiParameters = array() ) {
 
         $server = new \Hoa\Fastcgi\Responder(
             new \Hoa\Socket\Client($socket)
         );
 
-        return $server->send(array(
+        $headers = [
             'GATEWAY_INTERFACE' => 'FastCGI/1.0',
             'SERVER_PROTOCOL'   => 'HTTP/1.1',
-            'REQUEST_METHOD'    => 'GET',
             'REQUEST_URI'       => $workerPath,
             'SCRIPT_FILENAME'   => $workerPath,
             'SCRIPT_NAME'       => DS . dirname($workerPath)
-        ));
+        ];
+
+        $fastcgiParameters = array_merge([
+            'REQUEST_METHOD'    => 'GET'
+        ], $fastcgiParameters);
+
+        return $server->send(array_merge($fastcgiParameters, $headers));
     }
 
     /**


### PR DESCRIPTION
This PR is in relation with Issue #2

The new parameter are named **$fcgiParams**, with him, we can specify more parameters dedicated to `\Hoa\Fastcgi\Responder`.

It's useful for specify parameters dedicated to *Worker*, can read in *Super Global* **$_SERVER**.

**An Exception will be triggered when variable are different than array.**